### PR TITLE
增加两个在新建l所需的扩展

### DIFF
--- a/deploy-16.sh
+++ b/deploy-16.sh
@@ -72,7 +72,8 @@ apt-get install -y --force-yes php7.0-cli php7.0 \
 php-pgsql php-sqlite3 php-gd php-apcu \
 php-curl php7.0-mcrypt \
 php-imap php-mysql php-memcached php7.0-readline php-xdebug \
-php-mbstring php-xml php7.0-zip php7.0-intl php7.0-bcmath php-soap
+php-mbstring php-xml php7.0-zip php7.0-mbstring php7.0-dom \
+php7.0-soap php7.0-intl php7.0-bcmath php-soap
 
 # Install Composer
 


### PR DESCRIPTION
在创建laravel时cli模式缺少mbstring 和 dom扩展