### PR TITLE
修复无法成功安装nginx的问题

### DIFF
--- a/deploy-16.sh
+++ b/deploy-16.sh
@@ -68,7 +68,7 @@ ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
 # Install PHP Stuffs
 
-apt-get install -y --force-yes php7.1-cli php7.1 \
+apt-get install -y --force-yes php7.1-cli \
 php-pgsql php-sqlite3 php-gd php-apcu \
 php-curl php7.1-mcrypt \
 php-imap php-mysql php-memcached php7.1-readline php-xdebug \

--- a/deploy.sh
+++ b/deploy.sh
@@ -67,7 +67,7 @@ ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
 # Install PHP Stuffs
 
-apt-get install -y --force-yes php7.1-cli php7.1 \
+apt-get install -y --force-yes php7.1-cli \
 php7.1-pgsql php7.1-sqlite3 php7.1-gd php7.1-apcu \
 php7.1-curl php7.1-mcrypt \
 php7.1-imap php7.1-mysql php7.1-memcached php7.1-readline php7.1-xdebug \


### PR DESCRIPTION
如果安装 php7的话会自动安装apache 导致后面nginx无法启动 只需要安装php-fpm就行
https://stackoverflow.com/questions/34880267/ubuntu-server-installing-php-7-without-apache



http://imgur.com/a/mHdTx